### PR TITLE
feat: add option to convert tabs into spaces

### DIFF
--- a/src/formatters/markdown.zig
+++ b/src/formatters/markdown.zig
@@ -292,6 +292,7 @@ pub fn writeTextElement(node: Node, ctx: *const WriteContext) anyerror!void {
     defer ctx.allocator.free(text);
 
     try ctx.writer.writeAll(text);
+    try ctx.writer.flush();
 }
 
 pub fn writeListItemElement(node: Node, ctx: *const WriteContext) anyerror!void {

--- a/src/formatters/markdown.zig
+++ b/src/formatters/markdown.zig
@@ -101,7 +101,7 @@ pub const Options = struct {
     /// custom element handlers for application-specific rendering logic.
     user_data: ?*anyopaque = null,
 
-    /// TODO: write docs :)
+    /// Optional number of spaces to convert tabs to.
     convert_tab_size: ?u8 = null,
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -74,17 +74,19 @@ fn processConfig() !void {
     var in_buf: [1024]u8 = undefined;
     var out_buf: [1024]u8 = undefined;
 
-    var reader = input_file.reader(&in_buf).interface;
-    var writer = output_file.writer(&out_buf).interface;
+    var file_reader = input_file.reader(&in_buf);
+    const reader = &file_reader.interface;
+    var file_writer = output_file.writer(&out_buf);
+    const writer = &file_writer.interface;
 
     var arena = ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const document = try lib.load(allocator, &reader, .{});
+    const document = try lib.load(allocator, reader, .{});
     defer document.deinit();
 
-    try renderDocument(allocator, document, &writer, .{});
+    try renderDocument(allocator, document, writer, .{});
 }
 
 const cwd = std.fs.cwd;

--- a/src/main.zig
+++ b/src/main.zig
@@ -64,7 +64,7 @@ fn processConfig() !void {
 
     switch (output_source) {
         .file => {
-            output_file = try cwd().openFile(config.output.?, .{});
+            output_file = try cwd().createFile(config.output.?, .{});
         },
         .stdout => {
             output_file = std.fs.File.stdout();

--- a/src/tokenizer.zig
+++ b/src/tokenizer.zig
@@ -313,23 +313,23 @@ fn canBeEscaped(byte: u8) bool {
     return std.mem.indexOfAny(u8, &.{byte}, escape_chars) != null;
 }
 
-fn isNewlineString(str: []const u8) bool {
-    if (str.len != 2) {
-        return false;
-    }
+// fn isNewlineString(str: []const u8) bool {
+//     if (str.len != 2) {
+//         return false;
+//     }
 
-    switch (str[0]) {
-        '\\' => {},
-        else => {
-            return false;
-        },
-    }
+//     switch (str[0]) {
+//         '\\' => {},
+//         else => {
+//             return false;
+//         },
+//     }
 
-    switch (str[1]) {
-        'n' => return true,
-        else => return false,
-    }
-}
+//     switch (str[1]) {
+//         'n' => return true,
+//         else => return false,
+//     }
+// }
 
 const State = enum {
     text,
@@ -422,10 +422,12 @@ pub fn tokenize(allocator: std.mem.Allocator, reader: *std.io.Reader, options: O
                 // append next byte
                 byte = next_byte;
                 escaped = true;
-            } else if (isNewlineString(&.{ byte, next_byte })) {
-                byte = '\n';
-                escaped = true;
-            } else {
+            }
+            //  else if (isNewlineString(&.{ byte, next_byte })) {
+            //     byte = '\n';
+            //     escaped = true;
+            // }
+            else {
                 // continue with next byte
                 try parsed.buffer.append(allocator, byte);
                 byte = next_byte;

--- a/src/tokenizer.zig
+++ b/src/tokenizer.zig
@@ -313,23 +313,23 @@ fn canBeEscaped(byte: u8) bool {
     return std.mem.indexOfAny(u8, &.{byte}, escape_chars) != null;
 }
 
-// fn isNewlineString(str: []const u8) bool {
-//     if (str.len != 2) {
-//         return false;
-//     }
+fn isNewlineString(str: []const u8) bool {
+    if (str.len != 2) {
+        return false;
+    }
 
-//     switch (str[0]) {
-//         '\\' => {},
-//         else => {
-//             return false;
-//         },
-//     }
+    switch (str[0]) {
+        '\\' => {},
+        else => {
+            return false;
+        },
+    }
 
-//     switch (str[1]) {
-//         'n' => return true,
-//         else => return false,
-//     }
-// }
+    switch (str[1]) {
+        'n' => return true,
+        else => return false,
+    }
+}
 
 const State = enum {
     text,
@@ -422,12 +422,10 @@ pub fn tokenize(allocator: std.mem.Allocator, reader: *std.io.Reader, options: O
                 // append next byte
                 byte = next_byte;
                 escaped = true;
-            }
-            //  else if (isNewlineString(&.{ byte, next_byte })) {
-            //     byte = '\n';
-            //     escaped = true;
-            // }
-            else {
+            } else if (isNewlineString(&.{ byte, next_byte })) {
+                byte = '\n';
+                escaped = true;
+            } else {
                 // continue with next byte
                 try parsed.buffer.append(allocator, byte);
                 byte = next_byte;


### PR DESCRIPTION
Adds an optional argument `convert_tab_size` to CLI and Markdown formatter options. The argument is optional the user may provide an integer in the range of [0, 255] to convert tabs into that number of spaces.

I just used `replaceOwned` to do this as that is what was already being done with turning `\n` to `\n\n` but this could be a point of improvement, changing points where we replace these with a alloc-less writer.

I was struggling run the executable for bbcodez to test this so I needed to make some additional fixes:
Fixes:
- Use `createFile` instead of `openFile` for creating the output file.
- Flush after writing a textElement, no output was being generated for text-only input.

bbcode:
```
this should show as a tab: "	"
this should show as a tab: `	`
this should show as a tab: [code]	[/code]
this should show as backslash t: "\t"
this should show as backslash t: `\t`
this should show as backslash t: [code]\t[/code]
escaped: \[code\]	[/code\]
```
generated markdown (4 space tabs):
```md
this should show as a tab: "    "

this should show as a tab: `    `

this should show as a tab: `    `

this should show as backslash t: "\t"

this should show as backslash t: `\t`

this should show as backslash t: `\t`

escaped: [code]    [/code]

```

Closes #1 